### PR TITLE
CLR-1 Add '--clustered' flag to generate the proper structure to launch a 2 node Liferay clustered environment

### DIFF
--- a/bin/cliferay
+++ b/bin/cliferay
@@ -2424,8 +2424,10 @@ EOF
       clusterName="LiferayElasticsearchCluster"
       ' > $BUNDLES2/osgi/configs/com.liferay.portal.search.elasticsearch7.config
 
+      BUNDLES2_TOMCAT_FOLDER=$(cliferay tomcat-folder | sed 's|/bundles/|/bundles2/|')
+
       # Modify the second node ports to avoid collision
-      sed -i -e 's/8080/9080/g' -e 's/8005/9005/g' -e 's/8443/9443/g' "$BUNDLES2/tomcat-9.0.98/conf/server.xml"
+      sed -i -e 's/8080/9080/g' -e 's/8005/9005/g' -e 's/8443/9443/g' "$BUNDLES2_TOMCAT_FOLDER/conf/server.xml"
 
     fi
 

--- a/bin/cliferay
+++ b/bin/cliferay
@@ -2418,11 +2418,13 @@ EOF
 
       # Add the necessary elasticsearch7 configurations for clustering with second node
       mkdir -p $BUNDLES2/osgi/configs
-      echo '
-      operationMode="REMOTE"
-      networkHostAddresses=["http://localhost:9201"]
-      clusterName="LiferayElasticsearchCluster"
-      ' > $BUNDLES2/osgi/configs/com.liferay.portal.search.elasticsearch7.config
+      cat <<EOF > "$BUNDLES2/osgi/configs/com.liferay.portal.search.elasticsearch7.configuration.ElasticsearchConfiguration.config"
+  operationMode="REMOTE"
+  networkHostAddresses=["http://localhost:9201"]
+  clusterName="LiferayElasticsearchCluster"
+EOF
+
+      sed -i 's/^[ \t]*//' $BUNDLES2/osgi/configs/com.liferay.portal.search.elasticsearch7.configuration.ElasticsearchConfiguration.config
 
       BUNDLES2_TOMCAT_FOLDER=$(cliferay tomcat-folder | sed 's|/bundles/|/bundles2/|')
 

--- a/bin/cliferay
+++ b/bin/cliferay
@@ -2324,6 +2324,7 @@ EOF
 
     # src/commands/run.sh
     BUNDLES=$(realpath $(cliferay folder)/../bundles)
+    PROJECT_FOLDER=$(realpath $(cliferay folder)/../)
     echo "
     # This file was created by cliferay $(cliferay --version).
     # Please do not alter it.
@@ -2362,9 +2363,70 @@ EOF
     " > $BUNDLES/portal-ext.properties
 
     if [[ ${args[--clustered]} -eq 1 ]]; then
+
+      # Add cluster property to 'portal-ext.properties'
       echo "
-        # Portal clustered mode enabled
-        cluster.link.enabled=true" >> $BUNDLES/portal-ext.properties
+      # Portal clustered mode enabled
+      cluster.link.enabled=true
+      " >> $BUNDLES/portal-ext.properties
+
+      PROJECT_FOLDER=$(realpath $(cliferay folder)/../)
+
+      # Copy 'bundles' as 'bundles2' for the second node
+      echo "Copying the content of 'bundles'..." && rm -rf $PROJECT_FOLDER/bundles2 && cp -r $PROJECT_FOLDER/bundles $PROJECT_FOLDER/bundles2 && echo "Done!"
+
+      BUNDLES2=$(realpath $(cliferay folder)/../bundles2)
+
+      # Change 'portal-ext.properties'
+      echo "
+      # This file was created by cliferay $(cliferay --version).
+      # Please do not alter it.
+      # Put your custom properties in the portal-custom.properties file instead.
+
+      admin.email.from.address=test@liferay.com
+      admin.email.from.name=Test Test
+      default.admin.email.address.prefix=test
+
+      captcha.enforce.disabled=true
+
+      company.security.strangers.verify=false
+      company.default.locale=en_US
+      company.default.time.zone=UTC
+      company.default.web.id=liferay.com
+
+      jdbc.default.driverClassName=com.mysql.cj.jdbc.Driver
+      jdbc.default.password=root
+      jdbc.default.url=jdbc:mysql://localhost/$(cliferay db-name)?characterEncoding=UTF-8&dontTrackOpenResources=true&holdResultsOpenOverStatementClose=true&serverTimezone=GMT&useFastDateParsing=false&useUnicode=true
+      jdbc.default.username=root
+
+      liferay.home=$BUNDLES2
+
+      setup.wizard.enabled=false
+      terms.of.use.required=false
+      passwords.default.policy.change.required=false
+      users.reminder.queries.required=false
+      users.reminder.queries.enabled=false
+      enterprise.product.notification.enabled=false
+
+      feature.flag.ui.visible[dev]=true
+
+      include-and-override=\${liferay.home}/portal-custom.properties
+
+      # Portal clustered mode enabled
+      cluster.link.enabled=true
+      " > $BUNDLES2/portal-ext.properties
+
+      # Add the necessary elasticsearch7 configurations for clustering with second node
+      mkdir -p $BUNDLES2/osgi/configs
+      echo '
+      operationMode="REMOTE"
+      networkHostAddresses=["http://localhost:9201"]
+      clusterName="LiferayElasticsearchCluster"
+      ' > $BUNDLES2/osgi/configs/com.liferay.portal.search.elasticsearch7.config
+
+      # Modify the second node ports to avoid collision
+      sed -i -e 's/8080/9080/g' -e 's/8005/9005/g' -e 's/8443/9443/g' "$BUNDLES2/tomcat-9.0.98/conf/server.xml"
+
     fi
 
     if [ ! -f "$BUNDLES/portal-custom.properties" ]; then

--- a/bin/cliferay
+++ b/bin/cliferay
@@ -2315,7 +2315,7 @@ EOF
 
     # src/commands/nuke.sh
     cd $(cliferay folder)
-    rm -rf ../bundles/elasticsearch7 ../bundles/data ../bundles/osgi/war ../bundles/osgi/state $(cliferay tomcat-folder)/work/Catalina
+    rm -rf ../bundles/elasticsearch7 ../bundles/data ../bundles/osgi/war ../bundles/osgi/state ../bundles2 $(cliferay tomcat-folder)/work/Catalina
     echo "drop database IF EXISTS $(cliferay db-name); create database $(cliferay db-name) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin" | mysql -uroot -proot
   }
 

--- a/bin/cliferay
+++ b/bin/cliferay
@@ -616,13 +616,19 @@ cliferay() {
     printf "cliferay run - Start the server\n\n"
 
     printf "%s\n" "$(bold "Usage:")"
-    printf "  cliferay run [COMMAND]\n"
+    printf "  cliferay run [COMMAND] [OPTIONS]\n"
     printf "  cliferay run --help | -h\n"
     echo
 
     # :command.long_usage
     if [[ -n "$long_usage" ]]; then
       printf "%s\n" "$(bold "Options:")"
+
+      # :command.usage_flags
+      # :flag.usage
+      printf "  %s\n" "--clustered, -c"
+      printf "    Launch portal in dual-cluster mode\n"
+      echo
 
       # :command.usage_fixed_flags
       printf "  %s\n" "--help, -h"
@@ -1866,7 +1872,7 @@ cliferay() {
     echo $'      ;;'
     echo $''
     echo $'    \'run\'*)'
-    echo $'      while read -r; do COMPREPLY+=("$REPLY"); done < <(compgen -W "$(_cliferay_completions_filter "--help -h")" -- "$cur")'
+    echo $'      while read -r; do COMPREPLY+=("$REPLY"); done < <(compgen -W "$(_cliferay_completions_filter "--clustered --help -c -h")" -- "$cur")'
     echo $'      ;;'
     echo $''
     echo $'    \'ant\'*)'
@@ -2354,6 +2360,12 @@ EOF
 
     include-and-override=\${liferay.home}/portal-custom.properties
     " > $BUNDLES/portal-ext.properties
+
+    if [[ ${args[--clustered]} -eq 1 ]]; then
+      echo "
+        # Portal clustered mode enabled
+        cluster.link.enabled=true" >> $BUNDLES/portal-ext.properties
+    fi
 
     if [ ! -f "$BUNDLES/portal-custom.properties" ]; then
         echo "# Override your config here, don't touch portal-ext.properties" > $BUNDLES/portal-custom.properties
@@ -4143,6 +4155,13 @@ EOF
     while [[ $# -gt 0 ]]; do
       key="$1"
       case "$key" in
+        # :flag.case
+        --clustered | -c)
+
+          # :flag.case_no_arg
+          args['--clustered']=1
+          shift
+          ;;
 
         -?*)
           printf "invalid option: %s\n" "$key" >&2

--- a/src/bashly.yml
+++ b/src/bashly.yml
@@ -12,7 +12,7 @@ dependencies:
 commands:
 
   # cliferay
-  
+
   - name: aliases
     help: Print aliases script
     private: true
@@ -22,7 +22,7 @@ commands:
     help: Print completions script
     private: true
     group: cliferay
-  
+
   - name: data-folder
     help: Print the data folder
     private: true
@@ -161,6 +161,10 @@ commands:
       - name: command
         help: Tomcat command (jpda by default)
         required: false
+    flags:
+      - long: --clustered
+        short: -c
+        help: Launch portal in dual-cluster mode
 
   - name: tomcat-folder
     help: Print the current tomcat folder

--- a/src/commands/nuke.sh
+++ b/src/commands/nuke.sh
@@ -1,3 +1,3 @@
 cd $(cliferay folder)
-rm -rf ../bundles/elasticsearch7 ../bundles/data ../bundles/osgi/war ../bundles/osgi/state $(cliferay tomcat-folder)/work/Catalina
+rm -rf ../bundles/elasticsearch7 ../bundles/data ../bundles/osgi/war ../bundles/osgi/state ../bundles2 $(cliferay tomcat-folder)/work/Catalina
 echo "drop database IF EXISTS $(cliferay db-name); create database $(cliferay db-name) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin" | mysql -uroot -proot

--- a/src/commands/run.sh
+++ b/src/commands/run.sh
@@ -99,8 +99,10 @@ if [[ ${args[--clustered]} -eq 1 ]]; then
   clusterName="LiferayElasticsearchCluster"
   ' > $BUNDLES2/osgi/configs/com.liferay.portal.search.elasticsearch7.config
 
+  BUNDLES2_TOMCAT_FOLDER=$(cliferay tomcat-folder | sed 's|/bundles/|/bundles2/|')
+
   # Modify the second node ports to avoid collision
-  sed -i -e 's/8080/9080/g' -e 's/8005/9005/g' -e 's/8443/9443/g' "$BUNDLES2/tomcat-9.0.98/conf/server.xml"
+  sed -i -e 's/8080/9080/g' -e 's/8005/9005/g' -e 's/8443/9443/g' "$BUNDLES2_TOMCAT_FOLDER/conf/server.xml"
 
 fi
 

--- a/src/commands/run.sh
+++ b/src/commands/run.sh
@@ -93,11 +93,13 @@ if [[ ${args[--clustered]} -eq 1 ]]; then
 
   # Add the necessary elasticsearch7 configurations for clustering with second node
   mkdir -p $BUNDLES2/osgi/configs
-  echo '
+  cat <<EOF > "$BUNDLES2/osgi/configs/com.liferay.portal.search.elasticsearch7.configuration.ElasticsearchConfiguration.config"
   operationMode="REMOTE"
   networkHostAddresses=["http://localhost:9201"]
   clusterName="LiferayElasticsearchCluster"
-  ' > $BUNDLES2/osgi/configs/com.liferay.portal.search.elasticsearch7.config
+EOF
+
+  sed -i 's/^[ \t]*//' $BUNDLES2/osgi/configs/com.liferay.portal.search.elasticsearch7.configuration.ElasticsearchConfiguration.config
 
   BUNDLES2_TOMCAT_FOLDER=$(cliferay tomcat-folder | sed 's|/bundles/|/bundles2/|')
 

--- a/src/commands/run.sh
+++ b/src/commands/run.sh
@@ -1,4 +1,5 @@
 BUNDLES=$(realpath $(cliferay folder)/../bundles)
+PROJECT_FOLDER=$(realpath $(cliferay folder)/../)
 echo "
 # This file was created by cliferay $(cliferay --version).
 # Please do not alter it.
@@ -37,9 +38,70 @@ include-and-override=\${liferay.home}/portal-custom.properties
 " > $BUNDLES/portal-ext.properties
 
 if [[ ${args[--clustered]} -eq 1 ]]; then
+
+  # Add cluster property to 'portal-ext.properties'
   echo "
-    # Portal clustered mode enabled
-    cluster.link.enabled=true" >> $BUNDLES/portal-ext.properties
+  # Portal clustered mode enabled
+  cluster.link.enabled=true
+  " >> $BUNDLES/portal-ext.properties
+
+  PROJECT_FOLDER=$(realpath $(cliferay folder)/../)
+
+  # Copy 'bundles' as 'bundles2' for the second node
+  echo "Copying the content of 'bundles'..." && rm -rf $PROJECT_FOLDER/bundles2 && cp -r $PROJECT_FOLDER/bundles $PROJECT_FOLDER/bundles2 && echo "Done!"
+
+  BUNDLES2=$(realpath $(cliferay folder)/../bundles2)
+
+  # Change 'portal-ext.properties'
+  echo "
+  # This file was created by cliferay $(cliferay --version).
+  # Please do not alter it.
+  # Put your custom properties in the portal-custom.properties file instead.
+
+  admin.email.from.address=test@liferay.com
+  admin.email.from.name=Test Test
+  default.admin.email.address.prefix=test
+
+  captcha.enforce.disabled=true
+
+  company.security.strangers.verify=false
+  company.default.locale=en_US
+  company.default.time.zone=UTC
+  company.default.web.id=liferay.com
+
+  jdbc.default.driverClassName=com.mysql.cj.jdbc.Driver
+  jdbc.default.password=root
+  jdbc.default.url=jdbc:mysql://localhost/$(cliferay db-name)?characterEncoding=UTF-8&dontTrackOpenResources=true&holdResultsOpenOverStatementClose=true&serverTimezone=GMT&useFastDateParsing=false&useUnicode=true
+  jdbc.default.username=root
+
+  liferay.home=$BUNDLES2
+
+  setup.wizard.enabled=false
+  terms.of.use.required=false
+  passwords.default.policy.change.required=false
+  users.reminder.queries.required=false
+  users.reminder.queries.enabled=false
+  enterprise.product.notification.enabled=false
+
+  feature.flag.ui.visible[dev]=true
+
+  include-and-override=\${liferay.home}/portal-custom.properties
+
+  # Portal clustered mode enabled
+  cluster.link.enabled=true
+  " > $BUNDLES2/portal-ext.properties
+
+  # Add the necessary elasticsearch7 configurations for clustering with second node
+  mkdir -p $BUNDLES2/osgi/configs
+  echo '
+  operationMode="REMOTE"
+  networkHostAddresses=["http://localhost:9201"]
+  clusterName="LiferayElasticsearchCluster"
+  ' > $BUNDLES2/osgi/configs/com.liferay.portal.search.elasticsearch7.config
+
+  # Modify the second node ports to avoid collision
+  sed -i -e 's/8080/9080/g' -e 's/8005/9005/g' -e 's/8443/9443/g' "$BUNDLES2/tomcat-9.0.98/conf/server.xml"
+
 fi
 
 if [ ! -f "$BUNDLES/portal-custom.properties" ]; then

--- a/src/commands/run.sh
+++ b/src/commands/run.sh
@@ -36,6 +36,12 @@ module.framework.properties.osgi.console=11311
 include-and-override=\${liferay.home}/portal-custom.properties
 " > $BUNDLES/portal-ext.properties
 
+if [[ ${args[--clustered]} -eq 1 ]]; then
+  echo "
+    # Portal clustered mode enabled
+    cluster.link.enabled=true" >> $BUNDLES/portal-ext.properties
+fi
+
 if [ ! -f "$BUNDLES/portal-custom.properties" ]; then
     echo "# Override your config here, don't touch portal-ext.properties" > $BUNDLES/portal-custom.properties
 fi

--- a/src/lib/send_completions.sh
+++ b/src/lib/send_completions.sh
@@ -187,7 +187,7 @@ send_completions() {
   echo $'      ;;'
   echo $''
   echo $'    \'run\'*)'
-  echo $'      while read -r; do COMPREPLY+=("$REPLY"); done < <(compgen -W "$(_cliferay_completions_filter "--help -h")" -- "$cur")'
+  echo $'      while read -r; do COMPREPLY+=("$REPLY"); done < <(compgen -W "$(_cliferay_completions_filter "--clustered --help -c -h")" -- "$cur")'
   echo $'      ;;'
   echo $''
   echo $'    \'ant\'*)'


### PR DESCRIPTION
This new flag just generates the second bundles dir (named `bundles2`) with the necessary modifications to be run as the second node.

Now everything is working as expected.