### PR TITLE
fix(tomcat-folder) Sort by version before get the tomcat folder

### DIFF
--- a/bin/cliferay
+++ b/bin/cliferay
@@ -2444,7 +2444,7 @@ EOF
 
     # src/commands/tomcat-folder.sh
     cd $(cliferay folder)/../bundles
-    ls -d "$PWD/"** | grep tomcat | tail -n 1
+    ls -d "$PWD/"** | grep tomcat | sort --version-sort | tail -n 1
   }
 
   # :command.function

--- a/src/commands/tomcat-folder.sh
+++ b/src/commands/tomcat-folder.sh
@@ -1,2 +1,2 @@
 cd $(cliferay folder)/../bundles
-ls -d "$PWD/"** | grep tomcat | tail -n 1
+ls -d "$PWD/"** | grep tomcat | sort --version-sort | tail -n 1


### PR DESCRIPTION
Currently with the command `cliferay tomcat-folder` in getting the folder `bundles/tomcat-9.0.98` instead of `bundles/tomcat-9.0.102`

![image](https://github.com/user-attachments/assets/c820f1ce-dbda-4b66-a24d-52c1c79fc2d1)


